### PR TITLE
Log warning if cannot search in some locations

### DIFF
--- a/src/Api/Batch/Request.php
+++ b/src/Api/Batch/Request.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\OneDriveExtractor\Api\Batch;
 
 use Keboola\OneDriveExtractor\Api\Helpers;
+use Keboola\OneDriveExtractor\Exception\PropertyNotSetException;
 
 class Request
 {
@@ -17,16 +18,21 @@ class Request
     /** @var callable|null */
     private $responseMapper;
 
+    /** @var callable|null */
+    private $exceptionProcessor;
+
     public function __construct(
         string $id,
         string $uri,
         array $uriArgs,
         ?callable $responseMapper = null,
+        ?callable $exceptionProcessor = null,
         string $method = 'GET'
     ) {
         $this->id = $id;
         $this->uri = Helpers::replaceParamsInUri($uri, $uriArgs);
         $this->responseMapper = $responseMapper;
+        $this->exceptionProcessor = $exceptionProcessor;
         $this->method = $method;
     }
 
@@ -45,9 +51,30 @@ class Request
         return $this->method;
     }
 
-    public function getResponseMapper(): ?callable
+    public function hasResponseMapper(): bool
     {
+        return $this->responseMapper !== null;
+    }
+
+    public function getResponseMapper(): callable
+    {
+        if (!$this->responseMapper) {
+            throw new PropertyNotSetException('Response mapper is not set.');
+        }
         return $this->responseMapper;
+    }
+
+    public function hasExceptionProcessor(): bool
+    {
+        return $this->exceptionProcessor !== null;
+    }
+
+    public function getExceptionProcessor(): callable
+    {
+        if (!$this->exceptionProcessor) {
+            throw new PropertyNotSetException('Exception processor is not set.');
+        }
+        return $this->exceptionProcessor;
     }
 
     public function toArray(): array

--- a/src/Api/Model/Drive.php
+++ b/src/Api/Model/Drive.php
@@ -8,6 +8,8 @@ use InvalidArgumentException;
 
 class Drive
 {
+    private Site $site;
+
     private string $id;
 
     private array $path;
@@ -15,16 +17,22 @@ class Drive
     public static function from(array $data, Site $site): self
     {
         $path = ['sites', $site->getName(), $data['name']];
-        return new self($data['id'], $path);
+        return new self($site, $data['id'], $path);
     }
 
-    public function __construct(string $id, array $path)
+    public function __construct(Site $site, string $id, array $path)
     {
         if ($id === '') {
             throw new InvalidArgumentException('Drive id cannot be empty.');
         }
+        $this->site = $site;
         $this->id = $id;
         $this->path = $path;
+    }
+
+    public function getSite(): Site
+    {
+        return $this->site;
     }
 
     public function getId(): string

--- a/src/Exception/BatchRequestException.php
+++ b/src/Exception/BatchRequestException.php
@@ -5,8 +5,24 @@ declare(strict_types=1);
 namespace Keboola\OneDriveExtractor\Exception;
 
 use Keboola\CommonExceptions\ApplicationExceptionInterface;
+use Throwable;
 
 class BatchRequestException extends \Exception implements ApplicationExceptionInterface
 {
+    private string $originalMessage;
 
+    public function __construct(
+        string $message = '',
+        string $originalMessage = '',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->originalMessage = $originalMessage;
+    }
+
+    public function getOriginalMessage(): string
+    {
+        return $this->originalMessage;
+    }
 }

--- a/src/Exception/PropertyNotSetException.php
+++ b/src/Exception/PropertyNotSetException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveExtractor\Exception;
+
+use Keboola\CommonExceptions\ApplicationExceptionInterface;
+
+class PropertyNotSetException extends \Exception implements ApplicationExceptionInterface
+{
+
+}

--- a/tests/api/BatchRequestTest.php
+++ b/tests/api/BatchRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveExtractor\ApiTests;
+
+use Throwable;
+use PHPUnit\Framework\Assert;
+
+class BatchRequestTest extends BaseTest
+{
+    public function testEmptyBatchRequest(): void
+    {
+        // Test for bug COM-214, when empty batch request resulted to "BadRequest: Invalid batch payload format."
+        $batch = $this->api->createBatchRequest();
+        Assert::assertCount(0, iterator_to_array($batch->execute()));
+    }
+
+    public function testExceptionProcessor(): void
+    {
+        $batch = $this->api->createBatchRequest();
+        $batch->addRequest('/some/invalid/path1', [], null, function (Throwable $e): void {
+            $this->logger->warning('Warning, request 1 failed.');
+        });
+        $batch->addRequest('/some/invalid/path2', [], null, function (Throwable $e): void {
+            $this->logger->warning('Warning, request 2 failed.');
+        });
+        $results = iterator_to_array($batch->execute());
+        Assert::assertCount(0, $results);
+        Assert::assertSame([
+            'Warning, request 1 failed.',
+            'Warning, request 2 failed.',
+        ], array_map(fn(array $r) => $r['message'], $this->logger->records));
+    }
+}


### PR DESCRIPTION
Changes:
- Log warning (not exception) if extractor cannot search in some locations.
- For example, if OneDrive account is personal (not business), API returns Access Denied for search in `sharedWithMe` location, ... reported by JKotek: https://keboola.slack.com/archives/CMTBFNLF8/p1587452158033900?thread_ts=1585058840.079000&cid=CMTBFNLF8