### PR TITLE
Add optional metadata key

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ The configuration `config.json` contains following properties in `parameters` ke
     - `driveId` - string: id of [drive resource](https://docs.microsoft.com/en-us/graph/api/resources/drive?view=graph-rest-1.0)    
     - `fileId` - string: id of [driveItem resource](https://docs.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0)
     - `search` - string: in same format as in [Search Action](#search-action) 
+    - `metadata` - object (optional): 
+       - Serves to store human-readable data when `driveId` / `fileId` are used to define `workbook`.
+       - The component code is not using content of this metadata. 
+       - UI can use it to store and later show metadata from FilePicker.
 - `worksheet` - object (required): Worksheet, one sheet from workbook's sheets
     - `name` - string (required): Name of the output CSV file
     - One of `id` or `position` must be configured.
     - `id` - string: id of [worksheet resource](https://docs.microsoft.com/en-us/graph/api/resources/worksheet?view=graph-rest-1.0)
     - `position` - int: worksheet position, first is 0, hidden sheets are included
+    - `metadata` - object (optional): 
+       - Serves to store human-readable data (eg. sheet name ) when `id` is used to define `worksheet`.
+       - The component code is not using content of this metadata.
+       - UI can use it to store and later show metadata from FilePicker.
 
 **Examples of `config.json`**
 

--- a/src/Configuration/Parts/WorkbookDefinition.php
+++ b/src/Configuration/Parts/WorkbookDefinition.php
@@ -26,6 +26,8 @@ class WorkbookDefinition
                 ->scalarNode('fileId')->cannotBeEmpty()->end()
                 // ... OR by search (path, download url, ...)
                 ->scalarNode('search')->cannotBeEmpty()->end()
+                // optional metadata can be always present, it is not used in code
+                ->arrayNode('metadata')->ignoreExtraKeys(true)->end()
             ->end()
             // Not empty
             ->validate()

--- a/src/Configuration/Parts/WorksheetDefinition.php
+++ b/src/Configuration/Parts/WorksheetDefinition.php
@@ -27,6 +27,8 @@ class WorksheetDefinition
                 ->scalarNode('id')->cannotBeEmpty()->end()
                 // ... OR by position, first is 0, hidden sheets are included
                 ->scalarNode('position')->cannotBeEmpty()->end()
+                // optional metadata can be always present, it is not used in code
+                ->arrayNode('metadata')->ignoreExtraKeys(true)->end()
             ->end()
             // Only one of id/position allowed
             ->validate()

--- a/tests/phpunit/Config/GetWorksheetsConfigTest.php
+++ b/tests/phpunit/Config/GetWorksheetsConfigTest.php
@@ -55,6 +55,22 @@ class GetWorksheetsConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
+            'valid-ids-plus-metadata' => [
+                [
+                    'action' => 'getWorksheets',
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '1234abc',
+                            'fileId' => '5678def',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/phpunit/Config/RunConfigTest.php
+++ b/tests/phpunit/Config/RunConfigTest.php
@@ -91,6 +91,29 @@ class RunConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
+            'valid-plus-metadata' => [
+                [
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '1234abc',
+                            'fileId' => '5678def',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                        'worksheet' => [
+                            'name' => 'sheet-table',
+                            'id' => '9012xyz',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/phpunit/Config/SearchConfigTest.php
+++ b/tests/phpunit/Config/SearchConfigTest.php
@@ -55,6 +55,22 @@ class SearchConfigTest extends BaseConfigTest
                     ],
                 ],
             ],
+            'valid-plus-metadata' => [
+                [
+                    'action' => 'search',
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '...',
+                            'fileId' => '...',
+                            'metadata' => [
+                                'a' => 1,
+                                'b' => 'abc',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Solving: https://keboola.atlassian.net/browse/COM-243
Slack: https://keboolaglobal.slack.com/archives/C5K31TYKT/p1588604353057200?thread_ts=1587710396.021200&cid=C5K31TYKT

Changes:
 - Added optional `metadata` key for `workbook` and `worksheet`.
 - UI define `workbook` and `worksheet` by their `ID`s, because it is the most stable choice, ... file can be moved and component will be still working.
- ... but it is needed to store human-readable metadata, ... user needs see more info, than just `id`.
 - This metadata is not used in component code.