### PR TITLE
Convert 501 - operation not supported to user error

### DIFF
--- a/src/Api/Helpers.php
+++ b/src/Api/Helpers.php
@@ -7,6 +7,7 @@ namespace Keboola\OneDriveExtractor\Api;
 use Keboola\OneDriveExtractor\Exception\AccessDeniedException;
 use Keboola\OneDriveExtractor\Exception\BadRequestException;
 use Keboola\OneDriveExtractor\Exception\GatewayTimeoutException;
+use Keboola\OneDriveExtractor\Exception\NotSupportedException;
 use Normalizer;
 use GuzzleHttp\Exception\RequestException;
 use InvalidArgumentException;
@@ -95,6 +96,13 @@ class Helpers
             return new BadRequestException(
                 'Bad request error. Please check configuration. ' .
                 'It can be caused by typo in an ID, or resource doesn\'t exists.',
+                $e->getCode(),
+                $e
+            );
+        } elseif ($e->getCode() === 501) {
+            $message = $error ?? $e->getMessage();
+            return new NotSupportedException(
+                'Operation not supported by API:' . $message,
                 $e->getCode(),
                 $e
             );

--- a/src/Exception/NotSupportedException.php
+++ b/src/Exception/NotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveExtractor\Exception;
+
+use Keboola\CommonExceptions\UserExceptionInterface;
+
+class NotSupportedException extends \Exception implements UserExceptionInterface
+{
+
+}


### PR DESCRIPTION
Jira: https://keboola.atlassian.net/browse/COM-483

V tomto sprinte sme fixli export velkych tabuliek z OneDrive.
Uz nie sme limitovaný 5M buniek.

Pri testovani som zisil, ze ak ma XSLX subor viac ako 50MB, tak sa cez API neda vobec otvorit.
Preto je potrebne tuto chybu previest na user error.