### PR TITLE
feat: Log status code of failed requests

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -386,7 +386,18 @@ class Api
                 }
 
                 // Retry if communication problems
-                if (strpos($e->getMessage(), 'There were communication or server problems')) {
+                if (str_contains(
+                    $e->getMessage(),
+                    'There were communication or server problems',
+                )) {
+                    return true;
+                }
+
+                // Retry on possible transient session error
+                if (str_contains(
+                    $e->getMessage(),
+                    'The session specified in the request does not exist or is invalid due to a transient error.',
+                )) {
                     return true;
                 }
             }

--- a/tests/datadir/extract-not-found-drive-id/expected-stderr
+++ b/tests/datadir/extract-not-found-drive-id/expected-stderr
@@ -1,2 +1,2 @@
 API request failed, uri: "%A", response: "%A".
-Not found error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists.
+Bad request error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists.

--- a/tests/datadir/get-worksheets-not-found-drive-id/expected-stderr
+++ b/tests/datadir/get-worksheets-not-found-drive-id/expected-stderr
@@ -1,2 +1,2 @@
 API request failed, uri: "%A", response: "%A".
-Not found error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists.
+Bad request error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists.

--- a/tests/fixtures/FixturesApi.php
+++ b/tests/fixtures/FixturesApi.php
@@ -58,7 +58,18 @@ class FixturesApi
                 }
 
                 // Retry if communication problems
-                if (strpos($e->getMessage(), 'There were communication or server problems')) {
+                if (str_contains(
+                    $e->getMessage(),
+                    'There were communication or server problems',
+                )) {
+                    return true;
+                }
+
+                // Retry on possible transient session error
+                if (str_contains(
+                    $e->getMessage(),
+                    'The session specified in the request does not exist or is invalid due to a transient error.',
+                )) {
                     return true;
                 }
             }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/SUPPORT-10915

Obcas se klientovi stane, ze mu job failne errorem

```
Job "850697634" ended with user error: "API request failed, uri: "https://graph.microsoft.com/v1.0/drives/b%21JEf-PjmUGUCqQoZL-PqjQgi5mEExN0tEj2eb5PjXA91VBA28Xt1dSpBocAppIpRL/items/01OROSE75NHFP4LW7S5VCYFYP2NZZCN2Q7/workbook/worksheets/%7B00000000-0001-0000-0000-000000000000%7D/range(address='A2%3AP31')?$select=address,text", response: "{"error":{"code":"InvalidSession","message":"The target session is invalid.","innerError":{"code":"invalidSessionReCreatable","message":"The session specified in the request does not exist or is invalid due to a transient error.","innerError":{"code":"InvalidOrTimedOutSession","message":"We noticed that you haven't been interacting with this workbook, so we paused your session."},"date":"2025-02-22T09:02:14","request-id":"a5538c9d-7738-42bd-ba8e-131ad919aa98","client-request-id":"a5538c9d-7738-42bd-ba8e-131ad919aa98"}}}".
Bad request error. Please check configuration. It can be caused by typo in an ID, or resource doesn't exists."
```

Z `Bad request error.` error usuzuju, ze by to mohl byt status `400`, ktery defaultne nedelame re-try, ale po vzoru existujiciho checku na `There were communication or server problems` jsem pridal `if` na message z toho erroru.

Na prvni dobrou jsem chtel rict, ze se session problemem asi retry nepomuze, ale jelikoz se to fakt deje jen nahodne a error sam zminuje `or is invalid due to a transient error.`, dal bych tomu sanci.