### PR TITLE
fix(SUPPORT-14649): add retry logic for InvalidSession errors

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -16,6 +16,7 @@ use Keboola\OneDriveExtractor\Api\Model\TableHeader;
 use Keboola\OneDriveExtractor\Api\Model\TableRange;
 use Keboola\OneDriveExtractor\Api\Model\Worksheet;
 use Keboola\OneDriveExtractor\Exception\GatewayTimeoutException;
+use Keboola\OneDriveExtractor\Exception\InvalidSessionException;
 use Keboola\OneDriveExtractor\Exception\ResourceNotFoundException;
 use Keboola\OneDriveExtractor\Exception\SheetEmptyException;
 use Keboola\OneDriveExtractor\Exception\UnexpectedCountException;
@@ -373,9 +374,15 @@ class Api
     public function createRetry(LoggerInterface $logger, int $maxAttempts = self::RETRY_MAX_TRIES): RetryProxy
     {
         $backOffPolicy = new ExponentialBackOffPolicy(1000);
-        $retryPolicy = new CallableRetryPolicy(function (\Throwable $e) {
+        $retryPolicy = new CallableRetryPolicy(function (\Throwable $e) use ($logger) {
             // Always retry on gateway timeout
             if ($e instanceof GatewayTimeoutException) {
+                return true;
+            }
+
+            // Retry on invalid session - Microsoft says this is a transient error
+            if ($e instanceof InvalidSessionException) {
+                $logger->info('Session expired, will retry request.');
                 return true;
             }
 
@@ -389,14 +396,6 @@ class Api
                 if (str_contains(
                     $e->getMessage(),
                     'There were communication or server problems',
-                )) {
-                    return true;
-                }
-
-                // Retry on possible transient session error
-                if (str_contains(
-                    $e->getMessage(),
-                    'The session specified in the request does not exist or is invalid due to a transient error.',
                 )) {
                     return true;
                 }

--- a/src/Api/Helpers.php
+++ b/src/Api/Helpers.php
@@ -8,6 +8,7 @@ use Keboola\OneDriveExtractor\Exception\AccessDeniedException;
 use Keboola\OneDriveExtractor\Exception\BadRequestException;
 use Keboola\OneDriveExtractor\Exception\BatchRequestException;
 use Keboola\OneDriveExtractor\Exception\GatewayTimeoutException;
+use Keboola\OneDriveExtractor\Exception\InvalidSessionException;
 use Keboola\OneDriveExtractor\Exception\NotSupportedException;
 use Normalizer;
 use GuzzleHttp\Exception\RequestException;
@@ -95,6 +96,14 @@ class Helpers
         } elseif ($error && strpos($error, 'BadRequest: ') === 0) {
             // eg. BadRequest: Tenant does not have a SPO license.
             return new BadRequestException($error, $e->getCode(), $e);
+        } elseif ($error && strpos($error, 'InvalidSession:') === 0) {
+            return new InvalidSessionException(
+                'OneDrive API session expired or is invalid. ' .
+                'The request will be retried automatically. ' .
+                'API error: ' . $error,
+                $e->getCode(),
+                $e
+            );
         } elseif ($e->getCode() === 400) {
             // BadRequest, eg. bad fileId, "-1, Microsoft.SharePoint.Client.InvalidClientQueryException"
             return new BadRequestException(

--- a/src/Exception/InvalidSessionException.php
+++ b/src/Exception/InvalidSessionException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveExtractor\Exception;
+
+use Keboola\CommonExceptions\UserExceptionInterface;
+
+class InvalidSessionException extends \Exception implements UserExceptionInterface
+{
+
+}


### PR DESCRIPTION
## Summary

Adds retry logic for Microsoft Graph API `InvalidSession` errors that started occurring around December 10, 2025. Microsoft's API now more aggressively times out workbook sessions due to inactivity, returning `invalidSessionReCreatable` errors.

**Changes:**
- New `InvalidSessionException` class to identify session expiration errors
- Detection of `InvalidSession:` errors in `Helpers::processRequestException` with improved user-facing error message
- Retry logic in `Api::createRetry` that retries requests when InvalidSession occurs
- Removed old string-based transient session error check (now handled by the exception)

This is a companion PR to the wr-onedrive fix.

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Verify retry actually works** - The retry sends the same request with the same `Workbook-Session-Id` header. Microsoft docs say to "recreate session and resume work" - verify that simply retrying works, or if the session ID needs to be cleared/recreated on retry
- [ ] **Verify error detection matches API response** - The detection uses `strpos($error, 'InvalidSession:') === 0` on the parsed error from `getErrorFromRequestException()`. Confirm this matches actual Microsoft Graph API error format (the old code checked for a different string in the raw exception message)
- [ ] **Test with actual InvalidSession error** - Run the component against a configuration that triggers the InvalidSession error to verify the retry works end-to-end

**Recommended test plan:**
1. Wait for CI (may fail due to expired OAuth tokens - unrelated to this change)
2. Deploy to test environment
3. Run against a workbook that previously failed with InvalidSession
4. Verify in logs that "Session expired, will retry request." message appears and the job succeeds

### Notes

- Microsoft documentation confirms `invalidSessionReCreatable` is a transient error: https://learn.microsoft.com/en-us/graph/workbook-error-handling
- Investigation found zero InvalidSession errors before Dec 10, 2025 - suggests Microsoft changed their API behavior
- Related wr-onedrive PR: https://github.com/keboola/wr-onedrive/pull/37

**Link to Devin run:** https://app.devin.ai/sessions/e5db42911bc0447d900b4947d83c6d5e
**Requested by:** zdenek.srotyr@keboola.com (@ZdenekSrotyr)