### PR TITLE
feat: add optional `range` config param to worksheet (SUPPORT-14931)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The configuration `config.json` contains following properties in `parameters` ke
        - Serves to store human-readable data (eg. sheet name ) when `id` is used to define `worksheet`.
        - The component code is not using content of this metadata.
        - UI can use it to store and later show metadata from FilePicker.
+    - `range` - string (optional): A1-notation cell range to import (e.g. `B5:Z1000`). The first row of the range is treated as the header. When omitted the full auto-detected `usedRange` is used (default behaviour).
 - `rowsLimit` - int (optional): Export only first N rows.
 - `cellsPerBulk` - int (optional) - default `1 000 000`. Maximum number of the cells loaded by the one API request.
 - `errorWhenEmpty` - bool (optional) - default `false`. When enabled, the extraction fails if the selected worksheet contains zero data rows.
@@ -42,6 +43,24 @@ Input sheet configured by IDs.
     "worksheet": {
       "name": "sheet-export",
       "id": "..."
+    }
+  }
+}
+```
+
+Input sheet configured by IDs with a custom cell range.
+```json
+{
+  "authorization": {"oauth_api":  "..."},
+  "parameters": {
+    "workbook": {
+      "driveId": "...",
+      "fileId": "..."
+    },
+    "worksheet": {
+      "name": "sheet-export",
+      "id": "...",
+      "range": "B5:Z1000"
     }
   }
 }

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -21,6 +21,7 @@ use Keboola\OneDriveExtractor\Exception\ResourceNotFoundException;
 use Keboola\OneDriveExtractor\Exception\SheetEmptyException;
 use Keboola\OneDriveExtractor\Exception\UnexpectedCountException;
 use Keboola\OneDriveExtractor\Exception\UnexpectedValueException;
+use Keboola\OneDriveExtractor\Exception\UserException;
 use Microsoft\Graph\Graph;
 use Microsoft\Graph\Http\GraphResponse;
 use Psr\Log\LoggerInterface;
@@ -146,10 +147,26 @@ class Api
         string $worksheetId,
         ?int $rowsLimit = null,
         int $cellsPerBulk = self::DEFAULT_CELLS_PER_BULK,
-        ?string $sessionId = null
+        ?string $sessionId = null,
+        ?string $range = null
     ): SheetContent {
-        $usedRange = $this->getUsedRange($driveId, $fileId, $worksheetId, $sessionId);
-        $header = $this->getWorksheetHeader($driveId, $fileId, $worksheetId, $sessionId);
+        if ($range !== null) {
+            try {
+                $tableRange = TableRange::from($range);
+            } catch (\InvalidArgumentException $e) {
+                throw new UserException(sprintf(
+                    'Invalid range "%s". Expected A1 notation, e.g. "B5:Z1000".',
+                    $range
+                ), 0, $e);
+            }
+            $this->logger->info(sprintf('Using configured range "%s".', $range));
+            $header = $this->getHeaderForRange($driveId, $fileId, $worksheetId, $tableRange, $sessionId);
+        } else {
+            $tableRange = $this->getUsedRange($driveId, $fileId, $worksheetId, $sessionId);
+            $header = $this->getWorksheetHeader($driveId, $fileId, $worksheetId, $sessionId);
+        }
+
+        $usedRange = $tableRange;
 
         // Is empty?
         if (empty($header->getColumns())) {
@@ -201,6 +218,46 @@ class Api
         $header = TableHeader::from($body['address'], $body['text'][0]);
 
         // Log
+        $this->logger->info(sprintf(
+            'Sheet header (%s:%s): %s',
+            $header->getStartCell(),
+            $header->getEndCell(),
+            Helpers::formatIterable($header->getColumns()),
+        ));
+
+        return $header;
+    }
+
+    private function getHeaderForRange(
+        string $driveId,
+        string $fileId,
+        string $worksheetId,
+        TableRange $range,
+        ?string $sessionId
+    ): TableHeader {
+        $headerAddress = $range->getStart() . $range->getFirstRowNumber()
+            . ':' . $range->getEnd() . $range->getFirstRowNumber();
+
+        $endpoint = '/drives/{driveId}/items/{fileId}/workbook/worksheets/{worksheetId}';
+        $uri = $endpoint . '/range(address=\'{address}\')?$select=address,text';
+        $headers = [];
+        if ($sessionId) {
+            $headers['Workbook-Session-Id'] = $sessionId;
+        }
+        $body = $this
+            ->get(
+                $uri,
+                [
+                    'driveId' => $driveId,
+                    'fileId' => $fileId,
+                    'worksheetId' => $worksheetId,
+                    'address' => $headerAddress,
+                ],
+                $headers
+            )
+            ->getBody();
+        $header = TableHeader::from($body['address'], $body['text'][0]);
+
         $this->logger->info(sprintf(
             'Sheet header (%s:%s): %s',
             $header->getStartCell(),

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -75,6 +75,16 @@ class Config extends BaseConfig
         return $this->getValue(['parameters', 'worksheet', 'name']);
     }
 
+    public function hasRange(): bool
+    {
+        return $this->getRange() !== null;
+    }
+
+    public function getRange(): ?string
+    {
+        return $this->getValue(['parameters', 'worksheet', 'range']);
+    }
+
     public function getRowsLimit(): ?int
     {
         return $this->getValue(['parameters', 'rowsLimit']);

--- a/src/Configuration/Parts/WorksheetDefinition.php
+++ b/src/Configuration/Parts/WorksheetDefinition.php
@@ -27,6 +27,8 @@ class WorksheetDefinition
                 ->scalarNode('id')->cannotBeEmpty()->end()
                 // ... OR by position, first is 0, hidden sheets are included
                 ->scalarNode('position')->cannotBeEmpty()->end()
+                // optional A1-notation range (e.g. "B5:Z1000"), first row = header
+                ->scalarNode('range')->defaultNull()->end()
                 // optional metadata can be always present, it is not used in code
                 ->arrayNode('metadata')->ignoreExtraKeys(true)->end()
             ->end()

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -59,6 +59,7 @@ class Extractor
                 $this->config->getRowsLimit(),
                 $this->config->getCellPerBulk(),
                 $sessionId,
+                $this->config->getRange(),
             );
         } catch (SheetEmptyException $e) {
             $message = 'Sheet is empty. Nothing was exported.';

--- a/tests/phpunit/Config/RunConfigTest.php
+++ b/tests/phpunit/Config/RunConfigTest.php
@@ -19,6 +19,35 @@ class RunConfigTest extends BaseConfigTest
         $this->addToAssertionCount(1); // Assert no error
     }
 
+    public function testRangeAccessors(): void
+    {
+        $configWithRange = new Config(
+            [
+                'authorization' => $this->getValidAuthorization(),
+                'parameters' => [
+                    'workbook' => ['driveId' => 'd', 'fileId' => 'f'],
+                    'worksheet' => ['name' => 'out', 'id' => 'w', 'range' => 'B5:Z1000'],
+                ],
+            ],
+            new ConfigDefinition()
+        );
+        $this->assertTrue($configWithRange->hasRange());
+        $this->assertSame('B5:Z1000', $configWithRange->getRange());
+
+        $configWithoutRange = new Config(
+            [
+                'authorization' => $this->getValidAuthorization(),
+                'parameters' => [
+                    'workbook' => ['driveId' => 'd', 'fileId' => 'f'],
+                    'worksheet' => ['name' => 'out', 'id' => 'w'],
+                ],
+            ],
+            new ConfigDefinition()
+        );
+        $this->assertFalse($configWithoutRange->hasRange());
+        $this->assertNull($configWithoutRange->getRange());
+    }
+
     /**
      * @dataProvider invalidConfigProvider
      */
@@ -110,6 +139,37 @@ class RunConfigTest extends BaseConfigTest
                                 'a' => 1,
                                 'b' => 'abc',
                             ],
+                        ],
+                    ],
+                ],
+            ],
+            'valid-with-range' => [
+                [
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '1234abc',
+                            'fileId' => '5678def',
+                        ],
+                        'worksheet' => [
+                            'name' => 'sheet-table',
+                            'id' => '9012xyz',
+                            'range' => 'B5:Z1000',
+                        ],
+                    ],
+                ],
+            ],
+            'valid-without-range' => [
+                [
+                    'authorization' => $this->getValidAuthorization(),
+                    'parameters' => [
+                        'workbook' => [
+                            'driveId' => '1234abc',
+                            'fileId' => '5678def',
+                        ],
+                        'worksheet' => [
+                            'name' => 'sheet-table',
+                            'id' => '9012xyz',
                         ],
                     ],
                 ],


### PR DESCRIPTION
## Summary

Adds an optional `parameters.worksheet.range` field (A1 notation, e.g. `B5:Z1000`) so users can extract a specific rectangle from a worksheet instead of the full `usedRange`. First row of the supplied range is treated as the header. When absent/null → existing behaviour (backward compatible).

**Phase 1 (backend only)** — testable via raw config JSON; no UI changes.

### Key changes

- `WorksheetDefinition` — new optional `scalarNode('range')->defaultNull()`
- `Config` — `hasRange()` / `getRange(): ?string` accessors
- `Api::getWorksheetContent()` — new `?string $range` param; when set, builds `TableRange::from($range)` and fetches the header from the first row of that range via `range(address='...')` instead of `usedRange/row(row=0)`. Malformed range → `UserException` with clear message.
- `Extractor::extract()` — passes `$this->config->getRange()` through
- Tests — config validation (range present, absent, accessors), all passing
- README — documents the new param with example

### How to test

Add `\"range\": \"B5:Z1000\"` to `parameters.worksheet` in raw config JSON, then run against the dev tag pushed by CI.

## Release Notes
**Justification, description**

New optional `range` parameter under `parameters.worksheet` allows users to specify an A1-notation cell range to import (e.g. `B5:Z1000`) instead of the full auto-detected `usedRange`. Addresses customer request to skip summary rows/columns at top or left of sheet (SUPPORT-14931).

**Plans for Customer Communication**

Direct notification to requesting customer (Slovenská sporiteľňa) once validated.

**Impact Analysis**

Backward compatible — `range` defaults to `null`, preserving existing behaviour. When set, only the specified rectangle is read; first row = header.

**Deployment Plan**

Branch build pushed to ECR automatically by CI. Test via `runtime.tag` in raw config before tagging a release.

**Rollback Plan**

Remove `range` from config JSON to revert to default `usedRange` behaviour. No schema migration needed.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/ab6c87f83717466fbac8431f213fed91
Requested by: @Jakuboola