### PR TITLE
Defensive fix: retry transient connection failures during OAuth token refresh (keboola.ex-onedrive)

### DIFF
--- a/src/Auth/RefreshTokenProvider.php
+++ b/src/Auth/RefreshTokenProvider.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 
 namespace Keboola\OneDriveExtractor\Auth;
 
+use GuzzleHttp\Exception\ConnectException;
 use Keboola\OneDriveExtractor\Exception\AccessTokenRefreshException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Token\AccessTokenInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Retry\BackOff\BackOffPolicyInterface;
+use Retry\BackOff\ExponentialBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
 
 class RefreshTokenProvider implements TokenProvider
 {
@@ -16,17 +23,30 @@ class RefreshTokenProvider implements TokenProvider
     private const TOKEN_ENDPOINT = '/oauth2/v2.0/token';
     private const SCOPES = ['offline_access', 'User.Read', 'Files.Read.All', 'Sites.Read.All'];
 
+    // The login endpoint sometimes drops the connection (eg. "cURL error 35 ... reset by peer").
+    // Such failures are transient, so the request is retried before the job is failed.
+    private const RETRY_MAX_ATTEMPTS = 5; // includes the initial try
+    private const RETRY_INITIAL_INTERVAL = 1000; // ms, doubled on each attempt
+    private const RETRY_EXCEPTIONS = [ConnectException::class];
+
     private string $appId;
 
     private string $appSecret;
 
     private TokenDataManager $dataManager;
 
-    public function __construct(string $appId, string $appSecret, TokenDataManager $dataManager)
-    {
+    private LoggerInterface $logger;
+
+    public function __construct(
+        string $appId,
+        string $appSecret,
+        TokenDataManager $dataManager,
+        ?LoggerInterface $logger = null
+    ) {
         $this->appId = $appId;
         $this->appSecret = $appSecret;
         $this->dataManager = $dataManager;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function get(): AccessTokenInterface
@@ -41,10 +61,7 @@ class RefreshTokenProvider implements TokenProvider
         // Try token from stored state, and from the configuration.
         foreach ($tokens as $token) {
             try {
-                $newToken = $provider->getAccessToken(
-                    'refresh_token',
-                    ['refresh_token' => $token->getRefreshToken()]
-                );
+                $newToken = $this->refreshToken($provider, ['refresh_token' => $token->getRefreshToken()]);
                 break;
             } catch (IdentityProviderException $exception) {
                 // try next token
@@ -64,7 +81,7 @@ class RefreshTokenProvider implements TokenProvider
         return $newToken;
     }
 
-    private function createOAuthProvider(string $appId, string $appSecret): GenericProvider
+    protected function createOAuthProvider(string $appId, string $appSecret): GenericProvider
     {
         return new GenericProvider([
             'clientId' => $appId,
@@ -74,5 +91,33 @@ class RefreshTokenProvider implements TokenProvider
             'urlResourceOwnerDetails' => '',
             'scopes' => implode(' ', self::SCOPES),
         ]);
+    }
+
+    /**
+     * Separate factory, so tests can replace the back-off with a no-op one.
+     */
+    protected function createBackOffPolicy(): BackOffPolicyInterface
+    {
+        return new ExponentialBackOffPolicy(self::RETRY_INITIAL_INTERVAL);
+    }
+
+    /**
+     * Refreshes the token, retrying only connection level failures.
+     *
+     * An invalid/expired token still fails on the first try (IdentityProviderException is not
+     * retried) and a persistent connection problem is re-thrown after the last attempt,
+     * so a failing refresh keeps failing the job.
+     */
+    private function refreshToken(GenericProvider $provider, array $options): AccessTokenInterface
+    {
+        $retryProxy = new RetryProxy(
+            new SimpleRetryPolicy(self::RETRY_MAX_ATTEMPTS, self::RETRY_EXCEPTIONS),
+            $this->createBackOffPolicy(),
+            $this->logger
+        );
+
+        return $retryProxy->call(function () use ($provider, $options): AccessTokenInterface {
+            return $provider->getAccessToken('refresh_token', $options);
+        });
     }
 }

--- a/src/Auth/RefreshTokenProvider.php
+++ b/src/Auth/RefreshTokenProvider.php
@@ -25,7 +25,10 @@ class RefreshTokenProvider implements TokenProvider
 
     // The login endpoint sometimes drops the connection (eg. "cURL error 35 ... reset by peer").
     // Such failures are transient, so the request is retried before the job is failed.
-    private const RETRY_MAX_ATTEMPTS = 5; // includes the initial try
+    // The token is refreshed from the Component constructor, so this runs for sync actions too.
+    // The ceiling is therefore kept at the value the sync actions already use for the API calls
+    // (see Component::__construct) => at most 1s + 2s of waiting before the job fails.
+    private const RETRY_MAX_ATTEMPTS = 3; // includes the initial try
     private const RETRY_INITIAL_INTERVAL = 1000; // ms, doubled on each attempt
     private const RETRY_EXCEPTIONS = [ConnectException::class];
 
@@ -107,6 +110,13 @@ class RefreshTokenProvider implements TokenProvider
      * An invalid/expired token still fails on the first try (IdentityProviderException is not
      * retried) and a persistent connection problem is re-thrown after the last attempt,
      * so a failing refresh keeps failing the job.
+     *
+     * Only ConnectException is retried, on purpose. It means the connection was never
+     * established, so the request provably never reached the server and it is safe to send
+     * again. Please do not extend the list with RequestException: a request that failed while
+     * the response was already in flight may have been processed, and because Microsoft rotates
+     * refresh tokens, replaying it would come back as "invalid_grant" and the user would be
+     * told to reset an authorization which is in fact still valid.
      */
     private function refreshToken(GenericProvider $provider, array $options): AccessTokenInterface
     {

--- a/src/Auth/TokenProviderFactory.php
+++ b/src/Auth/TokenProviderFactory.php
@@ -14,10 +14,13 @@ class TokenProviderFactory
 
     private ArrayObject $stateObject;
 
-    public function __construct(Config $config, ArrayObject $stateObject)
+    private ?LoggerInterface $logger;
+
+    public function __construct(Config $config, ArrayObject $stateObject, ?LoggerInterface $logger = null)
     {
         $this->config = $config;
         $this->stateObject = $stateObject;
+        $this->logger = $logger;
     }
 
     public function create(): TokenProvider
@@ -27,7 +30,8 @@ class TokenProviderFactory
         return new RefreshTokenProvider(
             $this->config->getOAuthApiAppKey(),
             $this->config->getOAuthApiAppSecret(),
-            $tokenDataManager
+            $tokenDataManager,
+            $this->logger
         );
     }
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -34,7 +34,7 @@ class Component extends BaseComponent
         $config = $this->getConfig();
         $this->stateObject = new ArrayObject($this->getInputState());
 
-        $tokenProviderFactory = new TokenProviderFactory($config, $this->stateObject);
+        $tokenProviderFactory = new TokenProviderFactory($config, $this->stateObject, $logger);
         $tokenProvider = $tokenProviderFactory->create();
         $apiFactory = new ApiFactory($logger, $tokenProvider);
         $maxAttempts = $this->isSyncAction() ? 3 : Api::RETRY_MAX_TRIES;

--- a/tests/phpunit/Auth/RefreshTokenProviderTest.php
+++ b/tests/phpunit/Auth/RefreshTokenProviderTest.php
@@ -27,7 +27,7 @@ class RefreshTokenProviderTest extends TestCase
         APP_ID = 'app-id',
         APP_SECRET = 'app-secret',
         // RefreshTokenProvider::RETRY_MAX_ATTEMPTS, including the initial try
-        MAX_ATTEMPTS = 5;
+        MAX_ATTEMPTS = 3;
 
     public function testConnectionErrorIsRetried(): void
     {

--- a/tests/phpunit/Auth/RefreshTokenProviderTest.php
+++ b/tests/phpunit/Auth/RefreshTokenProviderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\OneDriveExtractor\Tests\Auth;
+
+use ArrayObject;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Keboola\OneDriveExtractor\Auth\RefreshTokenProvider;
+use Keboola\OneDriveExtractor\Auth\TokenDataManager;
+use Keboola\OneDriveExtractor\Exception\AccessTokenRefreshException;
+use League\OAuth2\Client\Provider\GenericProvider;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use Retry\BackOff\BackOffPolicyInterface;
+use Retry\BackOff\NoBackOffPolicy;
+
+class RefreshTokenProviderTest extends TestCase
+{
+    private const
+        APP_ID = 'app-id',
+        APP_SECRET = 'app-secret',
+        // RefreshTokenProvider::RETRY_MAX_ATTEMPTS, including the initial try
+        MAX_ATTEMPTS = 5;
+
+    public function testConnectionErrorIsRetried(): void
+    {
+        // First attempt is killed by a connection reset, the second one succeeds
+        $handler = new MockHandler([
+            self::createConnectException(),
+            self::createTokenResponse(),
+        ]);
+
+        $state = new ArrayObject();
+        $token = $this->createProvider($handler, $state)->get();
+
+        Assert::assertSame('new-access-token', $token->getToken());
+        Assert::assertSame('new-refresh-token', $token->getRefreshToken());
+        Assert::assertCount(0, $handler, 'Both the failed and the successful attempt should be used.');
+        Assert::assertArrayHasKey(TokenDataManager::STATE_AUTH_DATA_KEY, $state);
+    }
+
+    public function testConnectionErrorIsRethrownAfterLastAttempt(): void
+    {
+        // The login endpoint is down for good => the job must still fail
+        $handler = new MockHandler(array_fill(0, self::MAX_ATTEMPTS, self::createConnectException()));
+
+        try {
+            $this->createProvider($handler, new ArrayObject())->get();
+            Assert::fail(sprintf('Expected "%s" to be thrown.', ConnectException::class));
+        } catch (ConnectException $e) {
+            Assert::assertStringContainsString('Connection reset by peer', $e->getMessage());
+            Assert::assertCount(0, $handler, 'All attempts should be used, and no more.');
+        }
+    }
+
+    public function testInvalidTokenIsNotRetried(): void
+    {
+        // An expired/revoked token is not a connection problem => fail immediately, as before
+        $handler = new MockHandler([
+            new Response(400, ['Content-Type' => 'application/json'], (string) json_encode([
+                'error' => 'invalid_grant',
+                'error_description' => 'The refresh token has expired.',
+            ])),
+        ]);
+
+        $state = new ArrayObject();
+
+        try {
+            $this->createProvider($handler, $state)->get();
+            Assert::fail(sprintf('Expected "%s" to be thrown.', AccessTokenRefreshException::class));
+        } catch (AccessTokenRefreshException $e) {
+            Assert::assertStringContainsString('please reset authorization', $e->getMessage());
+            Assert::assertCount(0, $handler, 'Only one attempt should be made.');
+            Assert::assertArrayNotHasKey(TokenDataManager::STATE_AUTH_DATA_KEY, $state);
+        }
+    }
+
+    private function createProvider(MockHandler $handler, ArrayObject $state): RefreshTokenProvider
+    {
+        $dataManager = new TokenDataManager(
+            ['access_token' => 'old-access-token', 'refresh_token' => 'old-refresh-token'],
+            $state
+        );
+        $httpClient = new Client(['handler' => HandlerStack::create($handler)]);
+
+        return new class (self::APP_ID, self::APP_SECRET, $dataManager, $httpClient) extends RefreshTokenProvider {
+            private ClientInterface $httpClient;
+
+            public function __construct(
+                string $appId,
+                string $appSecret,
+                TokenDataManager $dataManager,
+                ClientInterface $httpClient
+            ) {
+                parent::__construct($appId, $appSecret, $dataManager);
+                $this->httpClient = $httpClient;
+            }
+
+            protected function createOAuthProvider(string $appId, string $appSecret): GenericProvider
+            {
+                $provider = parent::createOAuthProvider($appId, $appSecret);
+                $provider->setHttpClient($this->httpClient);
+                return $provider;
+            }
+
+            protected function createBackOffPolicy(): BackOffPolicyInterface
+            {
+                // Keep the test fast, the real policy waits seconds between the attempts
+                return new NoBackOffPolicy();
+            }
+        };
+    }
+
+    private static function createConnectException(): ConnectException
+    {
+        return new ConnectException(
+            'cURL error 35: OpenSSL SSL_connect: Connection reset by peer in connection to ' .
+            'login.microsoftonline.com:443',
+            new Request('POST', 'https://login.microsoftonline.com/common/oauth2/v2.0/token')
+        );
+    }
+
+    private static function createTokenResponse(): Response
+    {
+        return new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+            'access_token' => 'new-access-token',
+            'refresh_token' => 'new-refresh-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary

Adds defensive handling for an unhandled `GuzzleHttp\Exception\ConnectException` observed in production.
No change to the component's behaviour on inputs that already worked.

## Root cause

`GuzzleHttp\Exception\ConnectException` — *"cURL error 35: OpenSSL SSL_connect: Connection reset by peer in connection to login.microsoftonline.com:443"* — raised at `src/Auth/RefreshTokenProvider.php:46` (the `refresh_token` call inside `RefreshTokenProvider::get()`), reached from `ApiFactory::create()` in the `Component` constructor.

The Microsoft login endpoint reset the TLS connection while the component was refreshing its OAuth access token at start-up. This refresh was the **only** HTTP call in the component that was not wrapped in a retry — every Microsoft Graph API call already goes through `RetryProxy` (`Api::createRetry()`, added for exactly this class of problem). So a single connection blip against the login endpoint killed the whole job with an opaque internal (application) error.

Classified as **transient**; 1 occurrence in the alert window.

## Fix

Wrapped the refresh call in the component's **existing** retry idiom (`keboola/retry`, already a direct dependency and already used in `src/Api/Api.php`): `RetryProxy` + `SimpleRetryPolicy` limited to `ConnectException` + `ExponentialBackOffPolicy(1000)`, **3 attempts** including the initial try. `RetryProxy` re-throws the last exception once the attempts are exhausted.

3 attempts is deliberate rather than a bigger number: the refresh runs from the `Component` constructor, so it is on the **sync-action** path too, and `Component::__construct` already caps sync-action API retries at 3 for that reason. The worst case is therefore ~3 s of waiting (1 s + 2 s) before the job fails, which still covers the single connection reset that was actually observed.

Only `ConnectException` is retried, also deliberately, and the code says why: the connection was never established, so the request provably never reached the server and is safe to replay. A mid-flight failure is not — Microsoft rotates refresh tokens, so replaying a request the server may already have processed would return `invalid_grant` and tell the user to reset an authorization that is in fact still valid.

Supporting, non-behavioural plumbing:

- `RefreshTokenProvider` takes an **optional** `?LoggerInterface` (defaults to `NullLogger`), wired through `TokenProviderFactory` from `Component`, so `RetryProxy`'s own "…Retrying… [Nx]" line lands in the job log instead of the retry being invisible. Both constructors keep their old signatures working (new params are optional and nullable).
- `createOAuthProvider()` is `protected` instead of `private`, and the back-off policy moved into a small `protected` factory, purely so the regression test can inject a mocked HTTP client and a no-op back-off.

## Behaviour impact: none — defensive-only

- Happy path unchanged: a refresh that succeeds on the first attempt returns the identical token, with no extra requests, sleeps or transforms. No outputs, transforms, schema, or config semantics touched.
- **Only** `ConnectException` is retried. An invalid/expired/revoked refresh token still throws `IdentityProviderException` on the very first try, is still caught by the existing per-token loop, and still ends as the same `AccessTokenRefreshException` ("…please reset authorization in the extractor configuration.") — asserted by a test.
- A persistent connection problem is re-thrown after the last attempt, so the job still fails. Nothing is swallowed into a success.
- Existing tests pass unchanged — no assertions modified or deleted, no existing test file touched.

## Evidence

Datadog logs (monitor `97152903`): https://app.datadoghq.eu/logs?query=%28status%3A%28critical%20OR%20emergency%29%20service%3Ajob-queue-runner%20-env%3A%28dev-%2A%20OR%20%2Atesting%2A%29%20%28%40component%3Akeboola.ex-onedrive%20OR%20%40extra.component%3Akeboola.ex-onedrive%29%29&from_ts=1785240183000&to_ts=1785283383000

## Tests

Added `tests/phpunit/Auth/RefreshTokenProviderTest.php` (3 cases, Guzzle `MockHandler`, hermetic, well under a second):

1. a connection reset on the first attempt is retried and the refresh then succeeds;
2. a permanently failing connection is re-thrown after exactly the last attempt (job still fails);
3. an invalid-grant response is **not** retried and still surfaces the existing "reset authorization" error.

Verified locally in the component's own Docker image (PHP 7.4):

- `vendor/bin/phpunit tests/phpunit` → **OK (285 tests, 318 assertions)** — 282 pre-existing + 3 new.
- Confirmed the new tests fail without the fix (1 error + 1 failure), so they genuinely guard the retry.
- `composer phplint` → no syntax error · `composer phpcs` → clean · `composer phpstan` (level max) → `[OK] No errors`.

### Note on the red `tests` job

The `tests` CI job fails at **PHPUnit bootstrap**, before any test runs, with:

```
Keboola\OneDriveExtractor\Exception\AccessTokenRefreshException:
Microsoft OAuth API token refresh failed, please reset authorization in the extractor configuration.
```

This is **pre-existing and unrelated to this PR** — `tests/bootstrap.php` uploads fixtures to a live OneDrive account, and the repository's stored OAuth refresh-token secret has expired. PRs #42 and #43, neither of which touches `src/Auth`, fail at the same point with the identical message; the last green `tests` run on `master` was in November 2025. The credentialed `tests-api` / `tests-datadir` suites are untouched by this change, and re-authorizing that CI secret is a separate maintenance task.